### PR TITLE
Password reset and email verification within the app

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,4 @@
+package.json
+package-lock.json
+client/package.json
+client/package-lock.json

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -3235,8 +3235,7 @@
     "decode-uri-component": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
-      "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
-      "dev": true
+      "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU="
     },
     "decompress-response": {
       "version": "3.3.0",
@@ -9838,8 +9837,21 @@
       "dev": true,
       "requires": {
         "prepend-http": "2.0.0",
-        "query-string": "5.1.0",
+        "query-string": "5.1.1",
         "sort-keys": "2.0.0"
+      },
+      "dependencies": {
+        "query-string": {
+          "version": "5.1.1",
+          "resolved": "https://registry.npmjs.org/query-string/-/query-string-5.1.1.tgz",
+          "integrity": "sha512-gjWOsm2SoGlgLEdAGt7a6slVOk9mGiXmPFMqrEhLQ68rhQuBnpfs3+EmlvqKyxnCo9/PPlF+9MtY02S1aFg+Jw==",
+          "dev": true,
+          "requires": {
+            "decode-uri-component": "0.2.0",
+            "object-assign": "4.1.1",
+            "strict-uri-encode": "1.1.0"
+          }
+        }
       }
     },
     "npm-run-path": {
@@ -11301,14 +11313,19 @@
       "dev": true
     },
     "query-string": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/query-string/-/query-string-5.1.0.tgz",
-      "integrity": "sha512-F3DkxxlY0AqD/rwe4YAwjRE2HjOkKW7TxsuteyrS/Jbwrxw887PqYBL4sWUJ9D/V1hmFns0SCD6FDyvlwo9RCQ==",
-      "dev": true,
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/query-string/-/query-string-6.0.0.tgz",
+      "integrity": "sha1-i485RHtz6CkNb141gXeSGOkXEUI=",
       "requires": {
         "decode-uri-component": "0.2.0",
-        "object-assign": "4.1.1",
-        "strict-uri-encode": "1.1.0"
+        "strict-uri-encode": "2.0.0"
+      },
+      "dependencies": {
+        "strict-uri-encode": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz",
+          "integrity": "sha1-ucczDHBChi9rFC3CdLvMWGbONUY="
+        }
       }
     },
     "querystring": {

--- a/client/package.json
+++ b/client/package.json
@@ -49,6 +49,7 @@
     "material-ui": "^0.20.0",
     "path-to-regexp": "^2.2.0",
     "prop-types": "^15.6.1",
+    "query-string": "^6.0.0",
     "react": "^16.2.0",
     "react-dom": "^16.2.0",
     "react-dropzone": "^4.2.9",

--- a/client/src/api/auth/Auth.js
+++ b/client/src/api/auth/Auth.js
@@ -92,6 +92,36 @@ class Auth {
     }
   };
 
+  confirmEmailAddress = async code => {
+    try {
+      await Auth.auth.sendapplyActionCode(code);
+    } catch (error) {
+      let err = errors.getErrorMessageForCode(error.code);
+      if (!err) err = errors.internalError;
+      throw err;
+    }
+  };
+
+  verifyPasswordResetCode = async code => {
+    try {
+      await Auth.auth.verifyPasswordResetCode(code);
+    } catch (error) {
+      let err = errors.getErrorMessageForCode(error.code);
+      if (!err) err = errors.internalError;
+      throw err;
+    }
+  };
+
+  changePassword = async (code, password) => {
+    try {
+      await Auth.auth.confirmPasswordReset(code, password);
+    } catch (error) {
+      let err = errors.getErrorMessageForCode(error.code);
+      if (!err) err = errors.internalError;
+      throw err;
+    }
+  };
+
   getCurrentUser = async () => {
     const user = Auth.auth.currentUser;
     return user;

--- a/client/src/api/auth/Auth.js
+++ b/client/src/api/auth/Auth.js
@@ -1,13 +1,13 @@
 import FirebaseApp from './FirebaseApp';
 import { signInUrl } from '../../routes';
 import errors from './errors';
+import { getRootUrl } from '../../utils/url';
 
 class Auth {
   // This is a private property
   static auth = FirebaseApp.auth();
 
-  // TODO: take from settings.json at root from branch ps/shares
-  continueUrlHome = 'http://localhost:8080';
+  continueUrlHome = getRootUrl();
 
   signInUrl = `${this.continueUrlHome}/${signInUrl}`;
 
@@ -94,7 +94,7 @@ class Auth {
 
   confirmEmailAddress = async code => {
     try {
-      await Auth.auth.sendapplyActionCode(code);
+      await Auth.auth.applyActionCode(code);
     } catch (error) {
       let err = errors.getErrorMessageForCode(error.code);
       if (!err) err = errors.internalError;
@@ -104,7 +104,7 @@ class Auth {
 
   verifyPasswordResetCode = async code => {
     try {
-      await Auth.auth.verifyPasswordResetCode(code);
+      return await Auth.auth.verifyPasswordResetCode(code);
     } catch (error) {
       let err = errors.getErrorMessageForCode(error.code);
       if (!err) err = errors.internalError;

--- a/client/src/api/auth/errors.js
+++ b/client/src/api/auth/errors.js
@@ -33,6 +33,14 @@ const fireBaseErrors = [
   {
     code: 'auth/email-already-in-use',
     message: 'La dirección de correo electrónico no está disponible.'
+  },
+  {
+    code: 'auth/expired-action-code',
+    message: 'El enlace de recuperación expiró.'
+  },
+  {
+    code: 'auth/invalid-action-code',
+    message: 'El enlace de recuperación no es válido.'
   }
 ];
 const errors = {

--- a/client/src/components/Auth/Auth.scss
+++ b/client/src/components/Auth/Auth.scss
@@ -40,3 +40,11 @@
     margin: auto;
   }
 }
+
+.loader {
+  color: $mute;
+  text-align: center;
+  > p {
+    margin-top: 1rem;
+  }
+}

--- a/client/src/components/Auth/EmailActions/ActionHandler.jsx
+++ b/client/src/components/Auth/EmailActions/ActionHandler.jsx
@@ -1,0 +1,95 @@
+import React, { Component, Fragment } from 'react';
+import { Link } from 'react-router-dom';
+import RaisedButton from 'material-ui/RaisedButton';
+import Paper from 'material-ui/Paper';
+import { getParam } from '../utils';
+import Auth from '../../../api/auth/Auth';
+import { signInUrl } from '../../../routes';
+import ResetPassword from './ResetPassword';
+
+const boxStyles = {
+  padding: '1rem'
+};
+
+class ActionHandler extends Component {
+  constructor(props) {
+    super(props);
+    const mode = getParam('mode');
+    const code = getParam('oobCode');
+
+    this.state = { mode, code };
+  }
+
+  async componentWillMount() {
+    const auth = new Auth();
+    const { mode, code } = this.state;
+    try {
+      let email = null;
+      switch (mode) {
+        case 'verifyEmail':
+          await auth.confirmEmailAddress(code);
+          this.setState({
+            successMsg: '¡Tu cuenta ha sido activada exitosamente!'
+          });
+          break;
+        case 'resetPassword':
+          // Validate code and get email address
+          email = await auth.verifyPasswordResetCode(code);
+          this.setState({ email });
+          break;
+        case 'recoverEmail':
+          // TODO: handle email recovery
+          break;
+        default:
+          break;
+      }
+    } catch (error) {
+      console.log(error);
+      this.setState({ errorMsg: error.message });
+    }
+  }
+
+  render() {
+    const { code, email, errorMsg, successMsg } = this.state;
+    let toRender = null;
+    if (successMsg) {
+      toRender = (
+        <Fragment>
+          <div className="alert alert-info alert-small">{successMsg}</div>
+          <Link to={signInUrl()}>
+            <RaisedButton label="Continuar" />
+          </Link>
+        </Fragment>
+      );
+    } else if (errorMsg) {
+      toRender = (
+        <Fragment>
+          <div className="alert alert-error alert-small">{errorMsg}</div>
+          <Link to={signInUrl()}>
+            <RaisedButton label="Continuar" />
+          </Link>
+        </Fragment>
+      );
+    } else {
+      toRender = <ResetPassword code={code} email={email} />;
+    }
+
+    return (
+      <div className="row">
+        <div className="col-xs-12 col-sm-offset-5 col-sm-3">
+          <Paper zDepth={2} style={boxStyles}>
+            <div className="row">
+              <div className="col-xs-12">{toRender}</div>
+            </div>
+          </Paper>
+        </div>
+      </div>
+    );
+  }
+}
+
+// ResetPassword.propTypes = {
+//   history: shape(History).isRequired
+// };
+
+export default ActionHandler;

--- a/client/src/components/Auth/EmailActions/ActionHandler.jsx
+++ b/client/src/components/Auth/EmailActions/ActionHandler.jsx
@@ -2,7 +2,8 @@ import React, { Component, Fragment } from 'react';
 import { Link } from 'react-router-dom';
 import RaisedButton from 'material-ui/RaisedButton';
 import Paper from 'material-ui/Paper';
-import { getParam } from '../utils';
+import FA from 'react-fontawesome';
+import { getParam, sleep } from '../utils';
 import Auth from '../../../api/auth/Auth';
 import { signInUrl } from '../../../routes';
 import ResetPassword from './ResetPassword';
@@ -16,11 +17,32 @@ class ActionHandler extends Component {
     super(props);
     const mode = getParam('mode');
     const code = getParam('oobCode');
-
-    this.state = { mode, code };
+    let error = null;
+    let title;
+    if (!mode || !code) error = 'El enlace de recuperación no es válido.';
+    switch (mode) {
+      case 'verifyEmail':
+        title = 'Confirmación de correo';
+        break;
+      case 'resetPassword':
+        title = 'Restablecer contraseña';
+        break;
+      case 'recoverEmail':
+      default:
+        // TODO: handle email recovery
+        title = 'Error';
+        error = 'Ocurrió un error inesperado.';
+        break;
+    }
+    this.state = { mode, code, title, error };
   }
 
   async componentWillMount() {
+    await sleep(1000);
+    if (this.state.error) {
+      this.setState({ errorMsg: this.state.error });
+      return;
+    }
     const auth = new Auth();
     const { mode, code } = this.state;
     try {
@@ -29,13 +51,14 @@ class ActionHandler extends Component {
         case 'verifyEmail':
           await auth.confirmEmailAddress(code);
           this.setState({
+            title: 'Confirmación de correo',
             successMsg: '¡Tu cuenta ha sido activada exitosamente!'
           });
           break;
         case 'resetPassword':
           // Validate code and get email address
           email = await auth.verifyPasswordResetCode(code);
-          this.setState({ email });
+          this.setState({ email, title: 'Restablecer contraseña' });
           break;
         case 'recoverEmail':
           // TODO: handle email recovery
@@ -44,20 +67,19 @@ class ActionHandler extends Component {
           break;
       }
     } catch (error) {
-      console.log(error);
       this.setState({ errorMsg: error.message });
     }
   }
 
   render() {
-    const { code, email, errorMsg, successMsg } = this.state;
+    const { mode, code, title, email, errorMsg, successMsg } = this.state;
     let toRender = null;
     if (successMsg) {
       toRender = (
         <Fragment>
           <div className="alert alert-info alert-small">{successMsg}</div>
           <Link to={signInUrl()}>
-            <RaisedButton label="Continuar" />
+            <RaisedButton label="Continuar" primary fullWidth />
           </Link>
         </Fragment>
       );
@@ -66,18 +88,27 @@ class ActionHandler extends Component {
         <Fragment>
           <div className="alert alert-error alert-small">{errorMsg}</div>
           <Link to={signInUrl()}>
-            <RaisedButton label="Continuar" />
+            <RaisedButton label="Continuar" primary fullWidth />
           </Link>
         </Fragment>
       );
-    } else {
+    } else if (mode === 'resetPassword' && email) {
       toRender = <ResetPassword code={code} email={email} />;
+    } else {
+      toRender = (
+        <div className="loader">
+          <FA name="circle-o-notch" className="" spin size="3x" />
+          <p>Validando</p>
+        </div>
+      );
     }
 
     return (
       <div className="row">
         <div className="col-xs-12 col-sm-offset-5 col-sm-3">
           <Paper zDepth={2} style={boxStyles}>
+            <h3 className="text-center">{title}</h3>
+            <div className="logo" />
             <div className="row">
               <div className="col-xs-12">{toRender}</div>
             </div>
@@ -87,9 +118,5 @@ class ActionHandler extends Component {
     );
   }
 }
-
-// ResetPassword.propTypes = {
-//   history: shape(History).isRequired
-// };
 
 export default ActionHandler;

--- a/client/src/components/Auth/EmailActions/ActionHandler.jsx
+++ b/client/src/components/Auth/EmailActions/ActionHandler.jsx
@@ -2,8 +2,7 @@ import React, { Component, Fragment } from 'react';
 import { Link } from 'react-router-dom';
 import RaisedButton from 'material-ui/RaisedButton';
 import Paper from 'material-ui/Paper';
-import FA from 'react-fontawesome';
-import { getQueryStringParam, sleep } from '../utils';
+import { getQueryStringParam } from '../utils';
 import Auth from '../../../api/auth/Auth';
 import { signInUrl } from '../../../routes';
 import ResetPassword from './ResetPassword';
@@ -37,7 +36,6 @@ class ActionHandler extends Component {
   }
 
   async componentWillMount() {
-    await sleep(1000);
     // if state has an error already from constructor, do nothing but show it
     if (this.state.errorMsg) return;
 
@@ -83,14 +81,7 @@ class ActionHandler extends Component {
       );
     } else if (mode === 'resetPassword' && email) {
       toRender = <ResetPassword code={code} email={email} />;
-    } else {
-      toRender = (
-        <div className="loader">
-          <FA name="circle-o-notch" className="" spin size="3x" />
-          <p>Validando</p>
-        </div>
-      );
-    }
+    } else toRender = null;
 
     return (
       <div className="row">

--- a/client/src/components/Auth/EmailActions/ResetPassword.jsx
+++ b/client/src/components/Auth/EmailActions/ResetPassword.jsx
@@ -1,0 +1,94 @@
+import React, { Component } from 'react';
+import { Link } from 'react-router-dom';
+import RaisedButton from 'material-ui/RaisedButton';
+import TextField from 'material-ui/TextField';
+import { string } from 'prop-types';
+import Form from '../../common/Form';
+import CustomTextField from '../CustomFormField/CustomTextField';
+import controls from '../controls';
+import { sleep } from '../utils';
+import Auth from '../../../api/auth/Auth';
+import { signInUrl } from '../../../routes';
+
+class ResetPassword extends Component {
+  state = { error: null, successMsg: null };
+
+  resetPassword = async data => {
+    this.setState({ error: null });
+
+    await sleep(300); // just to fake load time
+
+    try {
+      const { password } = data;
+      console.log(password);
+      const auth = new Auth();
+      const { code } = this.props;
+      await auth.confirmPasswordResetCode(code, password);
+      this.setState({
+        successMsg: 'Tu contraseña se actualizó correctamente.'
+      });
+    } catch (error) {
+      // show error
+      this.setState({
+        error: error.message
+      });
+    }
+  };
+
+  render() {
+    const { error, successMsg } = this.state;
+
+    if (successMsg) {
+      return (
+        <div className="row">
+          <div className="col-xs-12">
+            <div className="alert alert-info alert-small">{successMsg}</div>
+            <Link to={signInUrl()}>
+              <RaisedButton label="Continuar" />
+            </Link>
+          </div>
+        </div>
+      );
+    }
+
+    const { email } = this.props;
+    return (
+      <Form
+        onSubmit={this.resetPassword}
+        className="login password-recovery"
+        submitText="Confirmar"
+      >
+        {(updateValid, shouldValid) => (
+          <div className="password-recovery">
+            <p>Ingresa tu nueva contraseña.</p>
+            {error && (
+              <div className="alert alert-error alert-small">{error}</div>
+            )}
+
+            <div className="row">
+              <div className="col-xs-12">
+                <TextField value={email} disabled />
+              </div>
+            </div>
+            <div className="row">
+              <div className="col-xs-12">
+                <CustomTextField
+                  control={controls.user}
+                  onValidChange={updateValid}
+                  shouldValid={shouldValid}
+                />
+              </div>
+            </div>
+          </div>
+        )}
+      </Form>
+    );
+  }
+}
+
+ResetPassword.propTypes = {
+  code: string.isRequired,
+  email: string.isRequired
+};
+
+export default ResetPassword;

--- a/client/src/components/Auth/EmailActions/ResetPassword.jsx
+++ b/client/src/components/Auth/EmailActions/ResetPassword.jsx
@@ -20,10 +20,9 @@ class ResetPassword extends Component {
 
     try {
       const { password } = data;
-      console.log(password);
       const auth = new Auth();
       const { code } = this.props;
-      await auth.confirmPasswordResetCode(code, password);
+      await auth.changePassword(code, password);
       this.setState({
         successMsg: 'Tu contraseña se actualizó correctamente.'
       });
@@ -44,7 +43,7 @@ class ResetPassword extends Component {
           <div className="col-xs-12">
             <div className="alert alert-info alert-small">{successMsg}</div>
             <Link to={signInUrl()}>
-              <RaisedButton label="Continuar" />
+              <RaisedButton label="Continuar" primary fullWidth />
             </Link>
           </div>
         </div>
@@ -73,7 +72,7 @@ class ResetPassword extends Component {
             <div className="row">
               <div className="col-xs-12">
                 <CustomTextField
-                  control={controls.user}
+                  control={controls.password}
                   onValidChange={updateValid}
                   shouldValid={shouldValid}
                 />

--- a/client/src/components/Auth/EmailActions/ResetPassword.jsx
+++ b/client/src/components/Auth/EmailActions/ResetPassword.jsx
@@ -6,7 +6,6 @@ import { string } from 'prop-types';
 import Form from '../../common/Form';
 import CustomTextField from '../CustomFormField/CustomTextField';
 import controls from '../controls';
-import { sleep } from '../utils';
 import Auth from '../../../api/auth/Auth';
 import { signInUrl } from '../../../routes';
 
@@ -15,8 +14,6 @@ class ResetPassword extends Component {
 
   resetPassword = async data => {
     this.setState({ error: null });
-
-    await sleep(300); // just to fake load time
 
     try {
       const { password } = data;

--- a/client/src/components/Auth/utils.js
+++ b/client/src/components/Auth/utils.js
@@ -1,3 +1,5 @@
+import qs from 'query-string';
+
 export const validateRequired = (field, fieldErrorText, state, errors) => {
   const toUpdate = {};
   let isValid = true;
@@ -20,3 +22,6 @@ export const validateRequired = (field, fieldErrorText, state, errors) => {
 
 export const sleep = async ms =>
   new Promise(resolve => setTimeout(resolve, ms));
+
+/* eslint-disable no-restricted-globals */
+export const getParam = param => qs.parse(location.search)[param];

--- a/client/src/components/Auth/utils.js
+++ b/client/src/components/Auth/utils.js
@@ -24,4 +24,4 @@ export const sleep = async ms =>
   new Promise(resolve => setTimeout(resolve, ms));
 
 /* eslint-disable no-restricted-globals */
-export const getParam = param => qs.parse(location.search)[param];
+export const getQueryStringParam = param => qs.parse(location.search)[param];

--- a/client/src/components/Content.jsx
+++ b/client/src/components/Content.jsx
@@ -5,12 +5,14 @@ import {
   homeUrl,
   signInUrl,
   signUpUrl,
-  superAdminUrl
+  superAdminUrl,
+  emailActionHandlerUrl
 } from '../routes';
 import Auth from './Auth/Auth';
 import Home from './Home/Home';
 import CustomerAdmin from './CustomerAdmin/CustomerAdmin';
 import SuperAdmin from './SuperAdmin/SuperAdmin';
+import ActionHandler from './Auth/EmailActions/ActionHandler';
 
 const Content = () => (
   <main className="main">
@@ -20,6 +22,7 @@ const Content = () => (
       <Route path={signUpUrl()} component={Auth} />
       <Route path={adminUrl()} component={CustomerAdmin} />
       <Route path={superAdminUrl()} component={SuperAdmin} />
+      <Route path={emailActionHandlerUrl()} component={ActionHandler} />
     </Switch>
   </main>
 );

--- a/client/src/components/common/HOC/withCustomer.jsx
+++ b/client/src/components/common/HOC/withCustomer.jsx
@@ -6,9 +6,6 @@ import { getDisplayName } from '../SnackBar/withSnackBar';
 import withCustomers from './withCustomers';
 
 const getCustomer = (state, { email }) => {
-  console.log('getcustomer');
-  console.log(state);
-  console.log(email);
   const cust = state.customers.data.length
     ? {
         customer: state.customers.data.find(
@@ -16,7 +13,6 @@ const getCustomer = (state, { email }) => {
         )
       }
     : { customer: {} };
-  console.log(cust);
   return cust;
 };
 

--- a/client/src/routes.js
+++ b/client/src/routes.js
@@ -29,6 +29,7 @@ export const superAdminPromosUrl = r('/super-admin/promociones');
 export const superAdminClientsUrl = r('/super-admin/clientes');
 
 export const accountUrl = r('/cuenta');
+export const emailActionHandlerUrl = r('/cuentas');
 
 export const adminAccountUrl = r('/admin/cuenta');
 

--- a/client/src/styles/styles.scss
+++ b/client/src/styles/styles.scss
@@ -60,8 +60,8 @@ a {
 .paper {
   padding: 15px 20px;
 }
-// Text colors
 .text {
+  // Text colors
   &-white {
     color: $white;
   }
@@ -75,11 +75,17 @@ a {
   &-danger {
     color: $errorColor;
   }
+
+  // text align
+  &-center {
+    text-align: center;
+  }
 }
 
 /* alerts */
 .alert {
   padding: 1rem;
+  margin-bottom: 1rem;
   &.alert-small {
     padding: 0.5rem;
     font-size: 14px;

--- a/client/src/styles/variables.js
+++ b/client/src/styles/variables.js
@@ -14,6 +14,8 @@ export const $white = '#ffffff';
 export const $black = '#000000';
 export const $grayBg = '#f2f2f2';
 export const $gray = '#757575';
+export const $mute = '#9e9e9e';
+export const $errorColor = '#d50000';
 
 // sizes
 export const $headerHeight = '64px';

--- a/client/src/styles/variables.scss
+++ b/client/src/styles/variables.scss
@@ -15,7 +15,7 @@ $white: #ffffff;
 $black: #000000;
 $gray-bg: #f2f2f2;
 $mute: #9e9e9e;
-$errorColor: #d50000; // TODO: add to variables.js
+$errorColor: #d50000;
 
 /* sizes */
 $headerHeight: 64px;


### PR DESCRIPTION
close #48 

For email links to work, we need to change the firebase url for those operations at `Firebase > Authentication > Templates > Any > Edit icon > Customize action URL (bottom-right)` for the following: `http://<server:port>/cuentas` and Firebase will append `mode` and `oobCode` as query string parameters.

By the other hand I found out that **we can test by sending sending those emails using the app** (register, reset)  and taking the query string from the link and append that to our app at `.../cuentas?<here>`. (BTW: hope you have a better name for `/cuentas` haha).

I already tested using both ways (changing the URL in Firebase vs taking parameters from emails) but please test all you can. I am changing back to original URL in Firebase just in case...